### PR TITLE
feat(fmt): auto converting to indented heredoc

### DIFF
--- a/fmt/fmt.go
+++ b/fmt/fmt.go
@@ -1,6 +1,7 @@
 package fmt
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -82,6 +83,9 @@ func (h *Hcl) formatStringLiterals(body *hclwrite.Body) error {
 
 			switch t.Type {
 			case hclsyntax.TokenOHeredoc:
+				if !bytes.Contains(t.Bytes, []byte("<<-")) {
+					t.Bytes = []byte(strings.ReplaceAll(string(t.Bytes), "<<", "<<-"))
+				}
 				startHeredoc = true
 				next = true
 				continue

--- a/fmt/fmt_test.go
+++ b/fmt/fmt_test.go
@@ -35,11 +35,18 @@ func TestFormat(t *testing.T) {
 			"../testdata/directive_fmt.hcl",
 		},
 		{
-			"skip string with function",
+			"format with function",
 			map[string]string{
 				"block": "prettier ? --write --parser json",
 			},
 			"../testdata/with_func_fmt.hcl",
+		},
+		{
+			"auto indent heredoc",
+			map[string]string{
+				"policy": "prettier ? --write --parser json",
+			},
+			"../testdata/indent_heredoc_fmt.tf",
 		},
 	}
 

--- a/testdata/indent_heredoc_fmt.tf
+++ b/testdata/indent_heredoc_fmt.tf
@@ -1,0 +1,13 @@
+resource "aws_iam_policy" "allow_dynamodb_table_post" {
+  name   = "allow_post"
+  policy = <<EOT
+{
+"Version": "2012-10-17",
+"Statement": {
+"Effect": "Allow",
+"Action": "dynamodb:*",
+"Resource": "${aws_dynamodb_table.post.arn}"
+}
+}
+EOT
+}

--- a/testdata/indent_heredoc_fmt.tf.golden
+++ b/testdata/indent_heredoc_fmt.tf.golden
@@ -1,0 +1,13 @@
+resource "aws_iam_policy" "allow_dynamodb_table_post" {
+  name   = "allow_post"
+  policy = <<-EOT
+  {
+    "Version": "2012-10-17",
+    "Statement": {
+      "Effect": "Allow",
+      "Action": "dynamodb:*",
+      "Resource": "${aws_dynamodb_table.post.arn}"
+    }
+  }
+  EOT
+}


### PR DESCRIPTION
Add functionality to automatically indent heredoc strings by replacing '<<' with '<<-' if not already indented.